### PR TITLE
Adds support for use in node.js

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -171,4 +171,4 @@
 
   scope.Proxy['revocable'] = scope.Proxy.revocable;
   scope['Proxy'] = scope.Proxy;
-})(window);
+})(typeof module !== 'undefined' && module.exports ? global : window);


### PR DESCRIPTION
Passes a scope that is `global` in a node.js environment, and `window` in a browser one.

I checked the tests, and one is failing both before and after this change.