### PR TITLE
Replaces template strings with string concatenation

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -47,7 +47,7 @@
     let throwRevoked = function() {};
     lastRevokeFn = function() {
       throwRevoked = function(trap) {
-        throw new TypeError(`Cannot perform '${trap}' on a proxy that has been revoked`);
+        throw new TypeError('Cannot perform "' + trap + '" on a proxy that has been revoked');
       };
     };
 
@@ -57,7 +57,7 @@
     handler = {'get': null, 'set': null, 'apply': null, 'construct': null};
     for (let k in unsafeHandler) {
       if (!(k in handler)) {
-        throw new TypeError(`Proxy polyfill does not support trap '${k}'`);
+        throw new TypeError('Proxy polyfill does not support trap "'+ k + '"');
       }
       handler[k] = unsafeHandler[k];
     }


### PR DESCRIPTION
Hi,

I ran into problems using `proxy-polyfill` without running a transpiler since template strings are not supported in all browsers.
That's why I use string concatenation to make `proxy.js` work without a need for any infrastructure.

Kinds
Greg