### PR TITLE
point `main` to ES5-safe file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "proxy-polyfill",
   "version": "0.2.0",
   "description": "Polyfill for the Proxy object",
-  "main": "./src/index.js",
+  "main": "./proxy.min.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GoogleChrome/proxy-polyfill.git"


### PR DESCRIPTION
this should fix https://github.com/GoogleChrome/proxy-polyfill/issues/45

A common pattern is to include a polyfill as part of your webpack entry like:

```js

  entry: {
    'app': [
      'babel-polyfill',
      'proxy-polyfill',
      './src/app.js',
    ],
  },
```

But because `proxy-polyfill` is in `node_modules` it will not be transpiled by babel. As a result, browsers that need this polyfill do not support the ES6 syntax (like template literals) used in `src/index.js`